### PR TITLE
remove dependency on ancient mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 biomaj_core
-mock
 ldap3>=2.2.4
 pymongo>=3.12.3,<4
 py-bcrypt

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ config = {
         'Programming Language :: Python :: 3',
     ],
     'install_requires': requirements,
-    'tests_require': ['nose', 'mock'],
+    'tests_require': ['nose'],
     'test_suite': 'nose.collector',
     'packages': find_packages(),
     'include_package_data': True,

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -9,8 +9,7 @@ import logging
 import copy
 import stat
 import time
-
-from mock import patch
+from unittest.mock import patch
 
 from optparse import OptionParser
 


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.
